### PR TITLE
Fix ribbon crash when icon files are missing on startup

### DIFF
--- a/packages/revit-bridge-addin/src/Bridge/App.cs
+++ b/packages/revit-bridge-addin/src/Bridge/App.cs
@@ -100,9 +100,13 @@ namespace RevitBridge.Bridge
             );
             connectBtnData.ToolTip = "Start the MCP Bridge Server";
             connectBtnData.LongDescription = "Starts the RevitMCP Bridge Server to enable AI-powered automation and natural language control of Revit.";
-            connectBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(connectIconPath));
-            connectBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(connectIconPath));
-            connectBtnData.ToolTipImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(brandIconPath));
+            if (File.Exists(connectIconPath))
+            {
+                connectBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(connectIconPath));
+                connectBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(connectIconPath));
+            }
+            if (File.Exists(brandIconPath))
+                connectBtnData.ToolTipImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(brandIconPath));
 
             // Disconnect Button
             PushButtonData disconnectBtnData = new PushButtonData(
@@ -113,8 +117,11 @@ namespace RevitBridge.Bridge
             );
             disconnectBtnData.ToolTip = "Stop the MCP Bridge Server";
             disconnectBtnData.LongDescription = "Stops the RevitMCP Bridge Server and closes all active connections.";
-            disconnectBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(disconnectIconPath));
-            disconnectBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(disconnectIconPath));
+            if (File.Exists(disconnectIconPath))
+            {
+                disconnectBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(disconnectIconPath));
+                disconnectBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(disconnectIconPath));
+            }
 
             // Status Button
             PushButtonData statusBtnData = new PushButtonData(
@@ -125,8 +132,11 @@ namespace RevitBridge.Bridge
             );
             statusBtnData.ToolTip = "View Server Status and Statistics";
             statusBtnData.LongDescription = "Displays detailed information about the Bridge Server including connection status, statistics, and capabilities.";
-            statusBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(statusIconPath));
-            statusBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(statusIconPath));
+            if (File.Exists(statusIconPath))
+            {
+                statusBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(statusIconPath));
+                statusBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(statusIconPath));
+            }
 
             // Create stacked items for better layout
             connectionPanel.AddItem(connectBtnData);
@@ -145,8 +155,11 @@ namespace RevitBridge.Bridge
             );
             settingsBtnData.ToolTip = "Configure Bridge Settings";
             settingsBtnData.LongDescription = "Configure server settings, port, logging, and other options.";
-            settingsBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(settingsIconPath));
-            settingsBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(settingsIconPath));
+            if (File.Exists(settingsIconPath))
+            {
+                settingsBtnData.Image = new System.Windows.Media.Imaging.BitmapImage(new Uri(settingsIconPath));
+                settingsBtnData.LargeImage = new System.Windows.Media.Imaging.BitmapImage(new Uri(settingsIconPath));
+            }
             settingsBtnData.AvailabilityClassName = "RevitBridge.Bridge.CommandAvailability";
 
             // Help Button


### PR DESCRIPTION
## Summary
- Wrap all `BitmapImage` icon assignments in `CreateModernRibbonInterface` with `File.Exists` checks
- Prevents `FileNotFoundException` from aborting `OnStartup` when the `Icons` folder is absent
- The RevitMCP ribbon tab now appears correctly in Revit even without icon assets bundled

## Root Cause
The original code unconditionally called `new BitmapImage(new Uri(path))` for icon paths that don't exist in a standard installation (the `Icons` folder is not included in the build output). This threw a `FileNotFoundException` that was caught by the outer try/catch in `OnStartup`, which then returned `Result.Failed` — silently preventing the RevitMCP ribbon tab from ever appearing in Revit.

Note: the `Help` button already had the correct `File.Exists` guard — this fix applies the same pattern consistently to all other buttons (Connect, Disconnect, Status, Settings).

## Test Plan
- [ ] Build with `dotnet build -p:RevitVersion=2025`
- [ ] Copy `RevitBridge.dll` to `C:\ProgramData\RevitMCP\bin\`
- [ ] Restart Revit 2025 with no `Icons` folder present — confirm **RevitMCP** ribbon tab appears
- [ ] Confirm Connect / Disconnect / Status / Settings buttons are present (without icons)
- [ ] Place icon files in the `Icons` folder and confirm icons load correctly

Generated with [Claude Code](https://claude.com/claude-code)